### PR TITLE
Update RxCoordinator to have Swift 4.2 support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -8,7 +8,9 @@ pod 'SwiftLint'
 target 'langlog' do
   pod 'RxCocoa'
   pod 'RxSwift'
-  pod 'rx-coordinator'
+  pod 'rx-coordinator',
+    git: 'https://github.com/antonve/RxCoordinator',
+    branch: 'master'
   pod 'Then'
   pod 'ReactorKit'
   pod 'SnapKit',

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,8 +2,8 @@ PODS:
   - ReactorKit (1.2.0):
     - RxSwift (>= 4.0.0)
   - rx-coordinator (0.6.0):
-    - RxCocoa (~> 4.0)
-    - RxSwift (~> 4.0)
+    - RxCocoa (~> 4.3)
+    - RxSwift (~> 4.3)
   - RxCocoa (4.3.1):
     - RxSwift (~> 4.0)
   - RxSwift (4.3.1)
@@ -14,7 +14,7 @@ PODS:
 
 DEPENDENCIES:
   - ReactorKit
-  - rx-coordinator
+  - rx-coordinator (from `https://github.com/antonve/RxCoordinator`, branch `master`)
   - RxCocoa
   - RxSwift
   - SnapKit (from `https://github.com/SnapKit/SnapKit`, commit `6af44ff4c901df25c06e12651bec9a3a56dce0a5`)
@@ -25,7 +25,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - ReactorKit
-    - rx-coordinator
     - RxCocoa
     - RxSwift
     - SwiftFormat
@@ -33,18 +32,24 @@ SPEC REPOS:
     - Then
 
 EXTERNAL SOURCES:
+  rx-coordinator:
+    :branch: master
+    :git: https://github.com/antonve/RxCoordinator
   SnapKit:
     :commit: 6af44ff4c901df25c06e12651bec9a3a56dce0a5
     :git: https://github.com/SnapKit/SnapKit
 
 CHECKOUT OPTIONS:
+  rx-coordinator:
+    :commit: 1a897724cc89f72824b957218b398ea2fa5da4b1
+    :git: https://github.com/antonve/RxCoordinator
   SnapKit:
     :commit: 6af44ff4c901df25c06e12651bec9a3a56dce0a5
     :git: https://github.com/SnapKit/SnapKit
 
 SPEC CHECKSUMS:
   ReactorKit: 18ca466f1e77fef1827addeb921fba8ae14edd63
-  rx-coordinator: c58d3e272129410fff5f3382cee89a59f1047882
+  rx-coordinator: 974b02a2fd53d51f0a3ffe5fbf8453cd09711f58
   RxCocoa: 78763c7b07d02455598d9fc3c1ad091a28b73635
   RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
   SnapKit: 0de968a9fec17499afa29683b05d0c775b6d1c29
@@ -52,6 +57,6 @@ SPEC CHECKSUMS:
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
   Then: 71866660c7af35a7343831f7668e7cd2b62ee0f2
 
-PODFILE CHECKSUM: 18be31154c451a5cc43bb897e0fcbbec3c1094ba
+PODFILE CHECKSUM: 23179729d2d4db1379fe51570472bfeb5567d74c
 
 COCOAPODS: 1.5.3

--- a/Pods/Local Podspecs/rx-coordinator.podspec.json
+++ b/Pods/Local Podspecs/rx-coordinator.podspec.json
@@ -1,0 +1,32 @@
+{
+  "name": "rx-coordinator",
+  "version": "0.6.0",
+  "license": {
+    "type": "MIT"
+  },
+  "homepage": "https://github.com/quickbirdstudios/RxCoordinator",
+  "authors": {
+    "Stefan Kofler": "stefan.kofler@quickbirdstudios.com"
+  },
+  "summary": "Navigation framework based on coordinator pattern.",
+  "source": {
+    "git": "https://github.com/quickbirdstudios/RxCoordinator.git",
+    "tag": "0.6.0"
+  },
+  "module_name": "RxCoordinator",
+  "swift_version": "4.2",
+  "platforms": {
+    "ios": "9.0",
+    "tvos": "9.0"
+  },
+  "source_files": "RxCoordinator/Sources/*.swift",
+  "frameworks": "UIKit",
+  "dependencies": {
+    "RxSwift": [
+      "~> 4.3"
+    ],
+    "RxCocoa": [
+      "~> 4.3"
+    ]
+  }
+}

--- a/Pods/Manifest.lock
+++ b/Pods/Manifest.lock
@@ -2,8 +2,8 @@ PODS:
   - ReactorKit (1.2.0):
     - RxSwift (>= 4.0.0)
   - rx-coordinator (0.6.0):
-    - RxCocoa (~> 4.0)
-    - RxSwift (~> 4.0)
+    - RxCocoa (~> 4.3)
+    - RxSwift (~> 4.3)
   - RxCocoa (4.3.1):
     - RxSwift (~> 4.0)
   - RxSwift (4.3.1)
@@ -14,7 +14,7 @@ PODS:
 
 DEPENDENCIES:
   - ReactorKit
-  - rx-coordinator
+  - rx-coordinator (from `https://github.com/antonve/RxCoordinator`, branch `master`)
   - RxCocoa
   - RxSwift
   - SnapKit (from `https://github.com/SnapKit/SnapKit`, commit `6af44ff4c901df25c06e12651bec9a3a56dce0a5`)
@@ -25,7 +25,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
     - ReactorKit
-    - rx-coordinator
     - RxCocoa
     - RxSwift
     - SwiftFormat
@@ -33,18 +32,24 @@ SPEC REPOS:
     - Then
 
 EXTERNAL SOURCES:
+  rx-coordinator:
+    :branch: master
+    :git: https://github.com/antonve/RxCoordinator
   SnapKit:
     :commit: 6af44ff4c901df25c06e12651bec9a3a56dce0a5
     :git: https://github.com/SnapKit/SnapKit
 
 CHECKOUT OPTIONS:
+  rx-coordinator:
+    :commit: 1a897724cc89f72824b957218b398ea2fa5da4b1
+    :git: https://github.com/antonve/RxCoordinator
   SnapKit:
     :commit: 6af44ff4c901df25c06e12651bec9a3a56dce0a5
     :git: https://github.com/SnapKit/SnapKit
 
 SPEC CHECKSUMS:
   ReactorKit: 18ca466f1e77fef1827addeb921fba8ae14edd63
-  rx-coordinator: c58d3e272129410fff5f3382cee89a59f1047882
+  rx-coordinator: 974b02a2fd53d51f0a3ffe5fbf8453cd09711f58
   RxCocoa: 78763c7b07d02455598d9fc3c1ad091a28b73635
   RxSwift: fe0fd770a43acdb7d0a53da411c9b892e69bb6e4
   SnapKit: 0de968a9fec17499afa29683b05d0c775b6d1c29
@@ -52,6 +57,6 @@ SPEC CHECKSUMS:
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
   Then: 71866660c7af35a7343831f7668e7cd2b62ee0f2
 
-PODFILE CHECKSUM: 18be31154c451a5cc43bb897e0fcbbec3c1094ba
+PODFILE CHECKSUM: 23179729d2d4db1379fe51570472bfeb5567d74c
 
 COCOAPODS: 1.5.3

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -480,7 +480,7 @@
 		18ED2FEC75C5152AC3A1B255ED494417 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = RxSwift/Observables/Filter.swift; sourceTree = "<group>"; };
 		18F5DE55C761ED3A5E9DF7A7C0C56972 /* RxWebViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxWebViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxWebViewDelegateProxy.swift; sourceTree = "<group>"; };
 		19010E253A9BA4858C9066D3830AEA98 /* RxScrollViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxScrollViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxScrollViewDelegateProxy.swift; sourceTree = "<group>"; };
-		19184B52B4CFB872466CCBB385FFBAE0 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxSwift.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		19184B52B4CFB872466CCBB385FFBAE0 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		19F44608EEFCCBECF702C5ECFA7DA513 /* SnapKit.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = SnapKit.modulemap; sourceTree = "<group>"; };
 		1A9971940E8E5DD9BB6A30E688A20AB9 /* PrimitiveSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimitiveSequence.swift; path = RxSwift/Traits/PrimitiveSequence.swift; sourceTree = "<group>"; };
 		1AB545953187220D1BC5EAFCE79C3601 /* BooleanDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BooleanDisposable.swift; path = RxSwift/Disposables/BooleanDisposable.swift; sourceTree = "<group>"; };
@@ -557,7 +557,7 @@
 		486B6702748149BB51A256E264FED12B /* Stub.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stub.swift; path = Sources/ReactorKit/Stub.swift; sourceTree = "<group>"; };
 		494FDBCB72D0D5137F24220E13175954 /* SwitchIfEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwitchIfEmpty.swift; path = RxSwift/Observables/SwitchIfEmpty.swift; sourceTree = "<group>"; };
 		4B13AF8D4BEAB86F0AE8FACBB5E55D2E /* UIButton+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIButton+Rx.swift"; path = "RxCocoa/iOS/UIButton+Rx.swift"; sourceTree = "<group>"; };
-		4B17CD8044C5019544D87CF24D2C33A6 /* RxCoordinator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxCoordinator.framework; path = "rx-coordinator.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		4B17CD8044C5019544D87CF24D2C33A6 /* RxCoordinator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCoordinator.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4B18C4B94202BF51DA0BAF29AAFEB686 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Platform/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		4C390FA9D82E6BDC98755E1DEA3635E0 /* ObservableConvertibleType+SharedSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ObservableConvertibleType+SharedSequence.swift"; path = "RxCocoa/Traits/SharedSequence/ObservableConvertibleType+SharedSequence.swift"; sourceTree = "<group>"; };
 		4CD1BB147D2977A5B39CE1AC18608C26 /* Pods-langlog.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-langlog.debug.xcconfig"; sourceTree = "<group>"; };
@@ -610,7 +610,7 @@
 		6B8A28835689268CDB03952CEF79D83E /* UIAlertAction+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIAlertAction+Rx.swift"; path = "RxCocoa/iOS/UIAlertAction+Rx.swift"; sourceTree = "<group>"; };
 		6BC70854AEC88CECC16BEBC52A2B6472 /* UIControl+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIControl+Rx.swift"; path = "RxCocoa/iOS/UIControl+Rx.swift"; sourceTree = "<group>"; };
 		6C831621F8596141E93262B37237C1F6 /* PriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorityQueue.swift; path = Platform/DataStructures/PriorityQueue.swift; sourceTree = "<group>"; };
-		6EF31CB525DF6338CBDAA1DAF0BEF59F /* Pods_langlog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_langlog.framework; path = "Pods-langlog.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6EF31CB525DF6338CBDAA1DAF0BEF59F /* Pods_langlog.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_langlog.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6F23CFE945CB0F6CB80C73A4470F8952 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = RxSwift/SwiftSupport/SwiftSupport.swift; sourceTree = "<group>"; };
 		6F39E7AAD78F07A85AF67FE670D9BDDB /* BehaviorRelay+Driver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "BehaviorRelay+Driver.swift"; path = "RxCocoa/Traits/Driver/BehaviorRelay+Driver.swift"; sourceTree = "<group>"; };
 		71C89364DEFAE7B2C0DDB02256913857 /* rx-coordinator.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.module; path = "rx-coordinator.modulemap"; sourceTree = "<group>"; };
@@ -657,7 +657,7 @@
 		91188CAB179FCD89EC1BB68EC2DB5D06 /* UILayoutSupport+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UILayoutSupport+Extensions.swift"; path = "Source/UILayoutSupport+Extensions.swift"; sourceTree = "<group>"; };
 		917C3AB3784C75986EDA28C41A27C0D8 /* AnonymousObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousObserver.swift; path = RxSwift/Observers/AnonymousObserver.swift; sourceTree = "<group>"; };
 		93669768BF04F98ABA259550895794D8 /* SharedSequence+Operators.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SharedSequence+Operators.swift"; path = "RxCocoa/Traits/SharedSequence/SharedSequence+Operators.swift"; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		93C25D26122BA4CB8C64F8566610807B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		93EA11207E0B519E76102F9A95195A54 /* RxNavigationControllerDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxNavigationControllerDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxNavigationControllerDelegateProxy.swift; sourceTree = "<group>"; };
 		940567F1EB809178D06F0D46726A96FA /* TakeWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeWhile.swift; path = RxSwift/Observables/TakeWhile.swift; sourceTree = "<group>"; };
@@ -665,7 +665,7 @@
 		955A2BC6386443D2ED8FFD6834EE79E9 /* Reactor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reactor.swift; path = Sources/ReactorKit/Reactor.swift; sourceTree = "<group>"; };
 		97FB69178D23EAE9918ADB838FC79B64 /* _RX.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = _RX.m; path = RxCocoa/Runtime/_RX.m; sourceTree = "<group>"; };
 		9818AC1F28E30D982216DD05CBE68311 /* Using.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Using.swift; path = RxSwift/Observables/Using.swift; sourceTree = "<group>"; };
-		998658152F31AF8AE837542593F1966E /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = SnapKit.framework; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		998658152F31AF8AE837542593F1966E /* SnapKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SnapKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		99C32F4542F493C132EBCDC9E82139A6 /* ConcurrentDispatchQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentDispatchQueueScheduler.swift; path = RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift; sourceTree = "<group>"; };
 		99DB5B82A58D7F4B07BD931587CD657A /* ActionSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ActionSubject.swift; path = Sources/ReactorKit/ActionSubject.swift; sourceTree = "<group>"; };
 		9A01E3F8D54A836B069E180B1A7AD04D /* ConstraintInsetTarget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConstraintInsetTarget.swift; path = Source/ConstraintInsetTarget.swift; sourceTree = "<group>"; };
@@ -721,7 +721,7 @@
 		B76009DBBAD6CAD52278E035BC356220 /* AnonymousDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousDisposable.swift; path = RxSwift/Disposables/AnonymousDisposable.swift; sourceTree = "<group>"; };
 		B79505701CD7B419A77C008B337D78FA /* Route.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Route.swift; path = RxCoordinator/Sources/Route.swift; sourceTree = "<group>"; };
 		B7FE76229520BC0F568C0F27375FDA15 /* Completable+AndThen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Completable+AndThen.swift"; path = "RxSwift/Traits/Completable+AndThen.swift"; sourceTree = "<group>"; };
-		B94262CB378FB076E5942922BBD5165D /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxCocoa.framework; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B94262CB378FB076E5942922BBD5165D /* RxCocoa.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxCocoa.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9495030CDF4A56D953794DF27EC9E7E /* SnapKit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = SnapKit.xcconfig; sourceTree = "<group>"; };
 		B9583AF0400D1C37AC3C6CB70FCB5136 /* RxCocoa-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RxCocoa-prefix.pch"; sourceTree = "<group>"; };
 		BA5B85758C1DC67AC95266583BEA3043 /* Signal.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Signal.swift; path = RxCocoa/Traits/Signal/Signal.swift; sourceTree = "<group>"; };
@@ -780,7 +780,7 @@
 		E223E62AA7442AADBBB77A8072F76E27 /* InvocableScheduledItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InvocableScheduledItem.swift; path = RxSwift/Schedulers/Internal/InvocableScheduledItem.swift; sourceTree = "<group>"; };
 		E28D31DC1010844F86BEAEA443226A86 /* RxTextViewDelegateProxy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTextViewDelegateProxy.swift; path = RxCocoa/iOS/Proxies/RxTextViewDelegateProxy.swift; sourceTree = "<group>"; };
 		E29BB081C8D941C8485D3934E64BE80C /* SerialDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDisposable.swift; path = RxSwift/Disposables/SerialDisposable.swift; sourceTree = "<group>"; };
-		E3123AC24D63B6FB9E46DD4951FE6E8D /* Then.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Then.framework; path = Then.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3123AC24D63B6FB9E46DD4951FE6E8D /* Then.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Then.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E35B8E91C5437F423F19FC9BC3553293 /* SynchronizedUnsubscribeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedUnsubscribeType.swift; path = RxSwift/Concurrency/SynchronizedUnsubscribeType.swift; sourceTree = "<group>"; };
 		E3B949A85AAE443C2B7634A0D2B84A1F /* UIGestureRecognizer+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "UIGestureRecognizer+Rx.swift"; path = "RxCocoa/iOS/UIGestureRecognizer+Rx.swift"; sourceTree = "<group>"; };
 		E3C3CBF23F6E446938CDECA7C2EB03D6 /* _RXDelegateProxy.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = _RXDelegateProxy.h; path = RxCocoa/Runtime/include/_RXDelegateProxy.h; sourceTree = "<group>"; };
@@ -793,7 +793,7 @@
 		E944EA9B4DBA291437298CC51AAAA559 /* PriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorityQueue.swift; path = Platform/DataStructures/PriorityQueue.swift; sourceTree = "<group>"; };
 		E94B2E6CAFDF8D899411F9EEF99980B1 /* Pods-langlog-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-langlog-resources.sh"; sourceTree = "<group>"; };
 		EBDCBDCE78629D92113ACB53AA1F3E4F /* Platform.Darwin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Darwin.swift; path = Platform/Platform.Darwin.swift; sourceTree = "<group>"; };
-		EC07F7C909293403C0B5709DD69EF078 /* ReactorKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = ReactorKit.framework; path = ReactorKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EC07F7C909293403C0B5709DD69EF078 /* ReactorKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReactorKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC3AF9F41EE52B254E512DA925B7FAAF /* SynchronizedDisposeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedDisposeType.swift; path = RxSwift/Concurrency/SynchronizedDisposeType.swift; sourceTree = "<group>"; };
 		EC4314E98C56650A4D64A0090FD7E53F /* PublishRelay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PublishRelay.swift; path = RxCocoa/Traits/PublishRelay.swift; sourceTree = "<group>"; };
 		EC4C0C34CBFD986A25E58E4C5C1FB52E /* ObserveOn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOn.swift; path = RxSwift/Observables/ObserveOn.swift; sourceTree = "<group>"; };
@@ -912,7 +912,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = SwiftLint;
 			path = SwiftLint;
 			sourceTree = "<group>";
 		};
@@ -1070,7 +1069,6 @@
 				FA751BC59540E5CA1C26550DC3672E0D /* Zip+Collection.swift */,
 				D98909B5FE56DCB53526BA7C724FA632 /* Support Files */,
 			);
-			name = RxSwift;
 			path = RxSwift;
 			sourceTree = "<group>";
 		};
@@ -1226,7 +1224,6 @@
 				43B3EB28A0BA8FEA74A7B1E4D323F3E6 /* URLSession+Rx.swift */,
 				4A5AD0EEA756595F93D7E7686A9BABE9 /* Support Files */,
 			);
-			name = RxCocoa;
 			path = RxCocoa;
 			sourceTree = "<group>";
 		};
@@ -1271,7 +1268,6 @@
 				F97A6706A040CB3CC317EEDF51654EE8 /* View.swift */,
 				41F2D4607FEE0360DC5773B44F8A9F83 /* Support Files */,
 			);
-			name = ReactorKit;
 			path = ReactorKit;
 			sourceTree = "<group>";
 		};
@@ -1301,7 +1297,6 @@
 				5CB7C0B5C2F574C50CF08B94AF50BA97 /* Then.swift */,
 				DA8EF310CD48360D3C7B6C993BD9D215 /* Support Files */,
 			);
-			name = Then;
 			path = Then;
 			sourceTree = "<group>";
 		};
@@ -1327,7 +1322,6 @@
 				1880E751DA1042CAE14B7BB1E7ADFE54 /* UIView+Store.swift */,
 				51EB119A3503B60BF2CFAF48A1B76BD5 /* Support Files */,
 			);
-			name = "rx-coordinator";
 			path = "rx-coordinator";
 			sourceTree = "<group>";
 		};
@@ -1335,7 +1329,6 @@
 			isa = PBXGroup;
 			children = (
 			);
-			name = SwiftFormat;
 			path = SwiftFormat;
 			sourceTree = "<group>";
 		};
@@ -1439,7 +1432,6 @@
 				91188CAB179FCD89EC1BB68EC2DB5D06 /* UILayoutSupport+Extensions.swift */,
 				F12BE3202698A84AF9A15421F57D1DD9 /* Support Files */,
 			);
-			name = SnapKit;
 			path = SnapKit;
 			sourceTree = "<group>";
 		};
@@ -1670,6 +1662,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0930;
 				LastUpgradeCheck = 0930;
+				TargetAttributes = {
+					9EF0BA0F00217EF84E437B9407CE7D5D = {
+						LastSwiftMigration = 1000;
+					};
+				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -2207,19 +2204,14 @@
 				INFOPLIST_FILE = "Target Support Files/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/RxCocoa/RxCocoa.modulemap";
 				PRODUCT_MODULE_NAME = RxCocoa;
 				PRODUCT_NAME = RxCocoa;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2246,11 +2238,7 @@
 				INFOPLIST_FILE = "Target Support Files/Pods-langlog/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-langlog/Pods-langlog.modulemap";
 				OTHER_LDFLAGS = "";
@@ -2286,11 +2274,7 @@
 				INFOPLIST_FILE = "Target Support Files/Pods-langlog/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "Target Support Files/Pods-langlog/Pods-langlog.modulemap";
 				OTHER_LDFLAGS = "";
@@ -2300,14 +2284,45 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		39842E10CB19B184DB0A4975EAE097B1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D70B1F2A5E17CF67022B91AB856A050 /* rx-coordinator.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/rx-coordinator/rx-coordinator-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/rx-coordinator/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/rx-coordinator/rx-coordinator.modulemap";
+				PRODUCT_MODULE_NAME = RxCoordinator;
+				PRODUCT_NAME = RxCoordinator;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		470AF0A3E90794F86F04278C211A39DA /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2326,19 +2341,14 @@
 				INFOPLIST_FILE = "Target Support Files/Then/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Then/Then.modulemap";
 				PRODUCT_MODULE_NAME = Then;
 				PRODUCT_NAME = Then;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2364,11 +2374,7 @@
 				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
 				PRODUCT_MODULE_NAME = RxSwift;
 				PRODUCT_NAME = RxSwift;
@@ -2400,19 +2406,14 @@
 				INFOPLIST_FILE = "Target Support Files/SnapKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SnapKit/SnapKit.modulemap";
 				PRODUCT_MODULE_NAME = SnapKit;
 				PRODUCT_NAME = SnapKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2438,11 +2439,7 @@
 				INFOPLIST_FILE = "Target Support Files/SnapKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/SnapKit/SnapKit.modulemap";
 				PRODUCT_MODULE_NAME = SnapKit;
 				PRODUCT_NAME = SnapKit;
@@ -2457,7 +2454,7 @@
 			};
 			name = Debug;
 		};
-		64C26B5CF4E7970BED62E7FBFF6F5EA0 /* Debug */ = {
+		61259D18D69239D1F3B87F233D641952 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1D70B1F2A5E17CF67022B91AB856A050 /* rx-coordinator.xcconfig */;
 			buildSettings = {
@@ -2474,56 +2471,15 @@
 				INFOPLIST_FILE = "Target Support Files/rx-coordinator/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/rx-coordinator/rx-coordinator.modulemap";
 				PRODUCT_MODULE_NAME = RxCoordinator;
 				PRODUCT_NAME = RxCoordinator;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.1;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		6A8A6B47C82716EE1A33EA8C898B21EB /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1D70B1F2A5E17CF67022B91AB856A050 /* rx-coordinator.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/rx-coordinator/rx-coordinator-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/rx-coordinator/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
-				MODULEMAP_FILE = "Target Support Files/rx-coordinator/rx-coordinator.modulemap";
-				PRODUCT_MODULE_NAME = RxCoordinator;
-				PRODUCT_NAME = RxCoordinator;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.1;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -2548,11 +2504,7 @@
 				INFOPLIST_FILE = "Target Support Files/RxCocoa/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/RxCocoa/RxCocoa.modulemap";
 				PRODUCT_MODULE_NAME = RxCocoa;
 				PRODUCT_NAME = RxCocoa;
@@ -2584,11 +2536,7 @@
 				INFOPLIST_FILE = "Target Support Files/Then/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/Then/Then.modulemap";
 				PRODUCT_MODULE_NAME = Then;
 				PRODUCT_NAME = Then;
@@ -2684,11 +2632,7 @@
 				INFOPLIST_FILE = "Target Support Files/ReactorKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/ReactorKit/ReactorKit.modulemap";
 				PRODUCT_MODULE_NAME = ReactorKit;
 				PRODUCT_NAME = ReactorKit;
@@ -2779,19 +2723,14 @@
 				INFOPLIST_FILE = "Target Support Files/ReactorKit/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/ReactorKit/ReactorKit.modulemap";
 				PRODUCT_MODULE_NAME = ReactorKit;
 				PRODUCT_NAME = ReactorKit;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2817,19 +2756,14 @@
 				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
 				PRODUCT_MODULE_NAME = RxSwift;
 				PRODUCT_NAME = RxSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
@@ -2889,8 +2823,8 @@
 		CE63B8017F453C27189A5D50F884E564 /* Build configuration list for PBXNativeTarget "rx-coordinator" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				64C26B5CF4E7970BED62E7FBFF6F5EA0 /* Debug */,
-				6A8A6B47C82716EE1A33EA8C898B21EB /* Release */,
+				39842E10CB19B184DB0A4975EAE097B1 /* Debug */,
+				61259D18D69239D1F3B87F233D641952 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Pods/SnapKit/Source/Typealiases.swift
+++ b/Pods/SnapKit/Source/Typealiases.swift
@@ -29,8 +29,8 @@ import Foundation
     typealias LayoutRelation = NSLayoutConstraint.Relation
     typealias LayoutAttribute = NSLayoutConstraint.Attribute
 #else
-    typealias LayoutRelation = NSLayoutConstraint.Relation
-    typealias LayoutAttribute = NSLayoutConstraint.Attribute
+    typealias LayoutRelation = NSLayoutRelation
+    typealias LayoutAttribute = NSLayoutAttribute
 #endif
     typealias LayoutPriority = UILayoutPriority
 #else

--- a/Pods/rx-coordinator/README.md
+++ b/Pods/rx-coordinator/README.md
@@ -197,7 +197,10 @@ If this is your first time using Carthage in the project, you'll need to go thro
 
 ### Manually
 
-If you prefer not to use any of the dependency managers, you can integrate RxCoordinator into your project manually, by downloading the source code and placing the files on your project directory.
+If you prefer not to use any of the dependency managers, you can integrate RxCoordinator into your project manually, by downloading the source code and placing the files on your project directory.  
+<br/><br/>
+If you want more information on RxCoordinator check out this blog post: 
+https://quickbirdstudios.com/blog/ios-navigation-library-based-on-the-coordinator-pattern/
 
 ## 👤 Author
 This tiny library is created with ❤️ by [QuickBird Studios](www.quickbirdstudios.com).

--- a/Pods/rx-coordinator/RxCoordinator/Sources/Animation.swift
+++ b/Pods/rx-coordinator/RxCoordinator/Sources/Animation.swift
@@ -11,10 +11,10 @@ import UIKit
 
 public class Animation: NSObject, UIViewControllerTransitioningDelegate {
 
-    public let presentationAnimation: TranistionAnimation?
-    public let dismissalAnimation: TranistionAnimation?
+    public let presentationAnimation: TransitionAnimation?
+    public let dismissalAnimation: TransitionAnimation?
 
-    public init(presentationAnimation: TranistionAnimation?, dismissalAnimation: TranistionAnimation?) {
+    public init(presentationAnimation: TransitionAnimation?, dismissalAnimation: TransitionAnimation?) {
         self.presentationAnimation = presentationAnimation
         self.dismissalAnimation = dismissalAnimation
     }

--- a/Pods/rx-coordinator/RxCoordinator/Sources/Coordinator.swift
+++ b/Pods/rx-coordinator/RxCoordinator/Sources/Coordinator.swift
@@ -73,7 +73,7 @@ extension Coordinator {
         let presentationObservable = self.presentationObservable(for: viewController)
         let dismissalObservable = self.dismissalObservable(for: viewController)
 
-        container.viewController.addChildViewController(viewController)
+        container.viewController.addChild(viewController)
 
         viewController.view.translatesAutoresizingMaskIntoConstraints = false
         container.view.addSubview(viewController.view)
@@ -83,7 +83,7 @@ extension Coordinator {
         container.view.topAnchor.constraint(equalTo: viewController.view.topAnchor).isActive = true
         container.view.bottomAnchor.constraint(equalTo: viewController.view.bottomAnchor).isActive = true
 
-        viewController.didMove(toParentViewController: container.viewController)
+        viewController.didMove(toParent: container.viewController)
 
         return TransitionObservables(presentation: presentationObservable, dismissal: dismissalObservable)
     }

--- a/Pods/rx-coordinator/RxCoordinator/Sources/InteractiveTransitionAnimation.swift
+++ b/Pods/rx-coordinator/RxCoordinator/Sources/InteractiveTransitionAnimation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public class InteractiveTransitionAnimation: NSObject, TranistionAnimation, UIViewControllerInteractiveTransitioning {
+public class InteractiveTransitionAnimation: NSObject, TransitionAnimation, UIViewControllerInteractiveTransitioning {
     public let duration: TimeInterval
     public let completionSpeed: CGFloat
     public let completionCurve: UIView.AnimationCurve

--- a/Pods/rx-coordinator/RxCoordinator/Sources/StaticTransitionAnimation.swift
+++ b/Pods/rx-coordinator/RxCoordinator/Sources/StaticTransitionAnimation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public class StaticTransitionAnimation: NSObject, TranistionAnimation {
+public class StaticTransitionAnimation: NSObject, TransitionAnimation {
     public let duration: TimeInterval
     public let performAnimation: (_ transitionContext: UIViewControllerContextTransitioning) -> Void
 

--- a/Pods/rx-coordinator/RxCoordinator/Sources/TransitionAnimation.swift
+++ b/Pods/rx-coordinator/RxCoordinator/Sources/TransitionAnimation.swift
@@ -9,7 +9,7 @@
 import Foundation
 import UIKit
 
-public protocol TranistionAnimation: UIViewControllerAnimatedTransitioning {
+public protocol TransitionAnimation: UIViewControllerAnimatedTransitioning {
     var duration: TimeInterval { get }
     var performAnimation: (_ transitionContext: UIViewControllerContextTransitioning) -> Void { get }
 }


### PR DESCRIPTION
## Why

It would need to be migrated every time the pods were updated. This was starting to get annoying.

## What

I've made a [fork](https://github.com/antonve/RxCoordinator) of RxCoordinator with has support for Swift 4.2. I've switched the repo to this one until the official one has support for 4.2.